### PR TITLE
Add server repo as dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,4 +40,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation 'tech.gusavila92:java-android-websocket-client:1.2.2'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.github.Splendor-Mobile-Game:ServerSide:develop-SNAPSHOT'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "SplendorMobileGame"


### PR DESCRIPTION
I added server repository as a dependency, so now we can use every public class and function we have written and tested in the server repo.

I managed to do it by using [jitpack](https://jitpack.io/). I don't know how exactly it works. I'm afraid that every time we have changed something on the server repo then we will have to go on jitpack site, paste in link to our server repo to search it out and click some button to refresh jitpack repository so it update to the newest version of our repo. 

If we didn't want to use jitpack then we would have to upload our server to maven or gradle repository.