### PR TITLE
Return if no reaction assigned to message

### DIFF
--- a/app/src/main/java/com/example/splendormobilegame/websocket/CustomWebSocketClient.java
+++ b/app/src/main/java/com/example/splendormobilegame/websocket/CustomWebSocketClient.java
@@ -74,6 +74,7 @@ public class CustomWebSocketClient extends WebSocketClient {
         if (reactionInstance == null) {
             Log.e("ReceivedMessage", "Message of type `" + serverMessageType + "` has been received," +
                     " but no instance has been assign to react to it!");
+            return;
         }
 
         UserMessage userMessage = null;


### PR DESCRIPTION
Android client has been crashing whenever received a message that has no assigned handler. Now it just logs the error and goes on.